### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/server/post-receive-trac.py
+++ b/server/post-receive-trac.py
@@ -64,7 +64,7 @@ for ticketId, commands in tickets.iteritems():
 
 	username = authorPattern.findall(author)[0]
 	now = datetime.now(utc)
-	message = "(On %s [changeset:%s %s]) %s" % (refname, rev, describe_tags, message)
+	message = "(On {0!s} [changeset:{1!s} {2!s}]) {3!s}".format(refname, rev, describe_tags, message)
 	ticket['branch'] = refname
 	ticket.save_changes(username, message, now, db, cnum+1)
 	db.commit()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:git-central?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:git-central?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
